### PR TITLE
Added a checkmark or x mark next to child agent in second dropdown

### DIFF
--- a/ui/app/views/jvm.html
+++ b/ui/app/views/jvm.html
@@ -73,14 +73,16 @@
           </option>
           <option data-divider="true">
           </option>
+          <option disabled>✔ - Live</option><option disabled>✖ - Dead</option>
           <option ng-repeat="item in childAgentRollups track by item.id"
                   data-href="{{agentRollupUrl(item.id)}}"
                   data-tokens="{{item.display}}"
                   value="{{item.id}}"
                   title="{{item.display}}"
                   ng-disabled="item.disabled"
-                  ng-selected="item.id == agentRollup.id">
-            {{item.indentedDisplay}}
+                  ng-selected="item.id == agentRollup.id"
+                  >
+                  {{item.status=='live' ? '✔- ' : '✖- '}}{{item.indentedDisplay}}
           </option>
           <option disabled
                   class="gt-child-agent-rollup-dropdown-message d-none"

--- a/ui/src/main/java/org/glowroot/ui/LayoutService.java
+++ b/ui/src/main/java/org/glowroot/ui/LayoutService.java
@@ -435,6 +435,7 @@ class LayoutService {
     @Value.Immutable
     interface FilteredChildAgentRollup {
         String id();
+        String status();
         String display(); // this is the child display (not including the top level display)
         String lastDisplayPart();
         boolean disabled(); // user has permission to a grandchild rollup, but not to child rollup

--- a/ui/src/main/java/org/glowroot/ui/UiModule.java
+++ b/ui/src/main/java/org/glowroot/ui/UiModule.java
@@ -141,7 +141,7 @@ public class UiModule {
         }
 
         List<Object> jsonServices = Lists.newArrayList();
-        jsonServices.add(new LayoutJsonService(activeAgentRepository, layoutService));
+        jsonServices.add(new LayoutJsonService(activeAgentRepository, layoutService, liveJvmService));
         jsonServices.add(new TransactionJsonService(transactionCommonService, traceCommonService,
                 aggregateRepository, configRepository, rollupLevelService, clock));
         jsonServices.add(new TracePointJsonService(traceRepository, liveTraceRepository,


### PR DESCRIPTION
Enhancements have been made to provide a more intuitive understanding of service/jvm status in the Glowroot UI. Now, when a top-level rollup is selected and the user navigates to a child rollup via the second dropdown menu, the status of each service/jvm is clearly marked. If the JVM for a service is active, a checkmark will be displayed next to the service name. Conversely, for inactive JVMs, an 'x' mark will be displayed. This new feature aims to provide a swift and visual understanding of the JVM status for each service. The key for dead/live will show as diabled options on top of the list. 
![image](https://github.com/tlew13/glowroot/assets/161374084/7b3ab2b8-5284-4558-a0c8-ac8a5272ccea)
